### PR TITLE
If scanning fails, return a copy of the defaults dict, not an empty dict

### DIFF
--- a/frontmatter/__init__.py
+++ b/frontmatter/__init__.py
@@ -40,7 +40,7 @@ def parse(text, **defaults):
         _, fm, content = FM_BOUNDARY.split(text, 2)
     except ValueError:
         # if we can't split, bail
-        return {}, text
+        return defaults.copy(), text
 
     # metadata is a dictionary, with defaults
     metadata = {}


### PR DESCRIPTION
Subject says it all. (Btw, this is the only way I can see to create a new Post object, short of instantiating one directly, which you've said not to do)