### PR TITLE
Use pyaml for deterministic dumps

### DIFF
--- a/frontmatter/__init__.py
+++ b/frontmatter/__init__.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals
 import codecs
 import re
 import yaml
+import pyaml
 
 from .util import u
 
@@ -93,7 +94,7 @@ def dumps(post):
     """
     Serialize post to a string and return text.
     """
-    metadata = yaml.safe_dump(post.metadata, default_flow_style=False).strip()
+    metadata = pyaml.dump(post.metadata, safe=True).strip()
     return POST_TEMPLATE.format(metadata=metadata, content=post.content).strip()
 
 

--- a/frontmatter/__init__.py
+++ b/frontmatter/__init__.py
@@ -40,7 +40,7 @@ def parse(text, **defaults):
         _, fm, content = FM_BOUNDARY.split(text, 2)
     except ValueError:
         # if we can't split, bail
-        return {}, text
+        return defaults.copy(), text
 
     # metadata is a dictionary, with defaults
     metadata = {}

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ with open('README.md') as f:
 
 requirements = [
     'PyYAML',
+    'pyaml'
     'six'
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('README.md') as f:
 
 requirements = [
     'PyYAML',
-    'pyaml'
+    'pyaml',
     'six'
 ]
 


### PR DESCRIPTION
There's no way to dump an OrderedDict with the standard PyYAML library. This means that keys can jump around in order (and data is dumped in other non diff-friendly ways). Swapping PyYAML dump calls for pyaml ones fixes this. 

(afaict pyaml works fine on python 3, despite not claiming this).

Any interest in adding this dependency?