### PR TITLE
Allow passing YAML arguments when dumping posts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ python:
   - "3.3"
   - "3.4"
 # command to install dependencies
-install: "python setup.py install"
+install: 
+# use pyaml for tests above py26
+ - if [[ $TRAVIS_PYTHON_VERSION != '2.6' ]]; then pip install pyaml; fi
+ - "python setup.py install"
 # command to run tests
 script: python test.py

--- a/frontmatter/__init__.py
+++ b/frontmatter/__init__.py
@@ -20,6 +20,7 @@ POST_TEMPLATE = """\
 ---
 {metadata}
 ---
+
 {content}
 """
 

--- a/test.py
+++ b/test.py
@@ -13,6 +13,11 @@ import six
 
 import frontmatter
 
+try:
+    import pyaml
+except ImportError:
+    pyaml = None
+
 
 class FrontmatterTest(unittest.TestCase):
     """
@@ -72,8 +77,7 @@ class FrontmatterTest(unittest.TestCase):
     def test_pretty_dumping(self):
         "Use pyaml to dump nicer"
         # pyaml only runs on 2.7 and above
-        if sys.version_info > (2, 6):
-            import pyaml
+        if sys.version_info > (2, 6) and pyaml is not None:
 
             with codecs.open('tests/unpretty.md', 'r', 'utf-8') as f:
                 data = f.read()

--- a/test.py
+++ b/test.py
@@ -3,10 +3,12 @@ from __future__ import unicode_literals
 from __future__ import print_function
 
 import codecs
+import doctest
 import glob
 import json
-import doctest
+import sys
 import unittest
+
 import six
 
 import frontmatter
@@ -16,6 +18,8 @@ class FrontmatterTest(unittest.TestCase):
     """
     Tests for parsing various kinds of content and metadata
     """
+    maxDiff = None
+
     def test_all_the_tests(self):
         "Sanity check that everything in the tests folder loads without errors"
         for filename in glob.glob('tests/*'):
@@ -64,6 +68,24 @@ class FrontmatterTest(unittest.TestCase):
             self.assertEqual(post_dict[k], v)
 
         self.assertEqual(post_dict['content'], post.content)
+
+    def test_pretty_dumping(self):
+        "Use pyaml to dump nicer"
+        # pyaml only runs on 2.7 and above
+        if sys.version_info > (2, 6):
+            import pyaml
+
+            with codecs.open('tests/unpretty.md', 'r', 'utf-8') as f:
+                data = f.read()
+
+            post = frontmatter.load('tests/unpretty.md')
+            yaml = pyaml.dump(post.metadata)
+
+            # the unsafe dumper gives you nicer output, for times you want that
+            dump = frontmatter.dumps(post, Dumper=pyaml.UnsafePrettyYAMLDumper)
+
+            self.assertEqual(dump, data)
+            self.assertTrue(yaml in dump)
 
 
 if __name__ == "__main__":

--- a/tests/chinese.txt
+++ b/tests/chinese.txt
@@ -1,4 +1,5 @@
 ---
 title: "Let's try unicode"
 ---
+
 欢迎来到大连水产学院！

--- a/tests/hello-world.markdown
+++ b/tests/hello-world.markdown
@@ -2,4 +2,5 @@
 title: Hello, world!
 layout: post
 ---
+
 Well, hello there, world.

--- a/tests/network-diagrams.markdown
+++ b/tests/network-diagrams.markdown
@@ -4,6 +4,7 @@ layout: post
 published: true
 tags: [todo]
 ---
+
 Kim Rees, sitting in for Nathan Yau at [Flowing Data](http://flowingdata.com), has been posting examples of [network diagrams](http://flowingdata.com/category/visualization/network-visualization/) lately. I have to confess I'm stumped by most of them them. Or maybe I'm just overwhelmed. Maybe I'm [not alone](http://flowingdata.com/2012/05/28/network-diagrams-simplified/):
 
 > Network diagrams are notoriously messy. Even a small number of nodes can be overwhelmed by their chaotic placement and relationships. [Cody Dunne](http://www.cs.umd.edu/~cdunne/) of [HCIL](http://www.cs.umd.edu/hcil/) showed off [his new work in simplifying these complex structures](http://www.cs.umd.edu/localphp/hcil/tech-reports-search.php?number=2012-11). In essence, he aggregates leaf nodes into a fan glyph that describes the underlying data in its size, arc, and color. Span nodes are similarly captured into crescent glyphs. The result is an easy to read, high level look at the network. You can easily compare different sections of the network, understand areas that may have been occluded by the lines in a traditional diagram, and see relationships far more quickly.

--- a/tests/unpretty.md
+++ b/tests/unpretty.md
@@ -1,0 +1,21 @@
+---
+destination:
+  encoding:
+    xz:
+      enabled: true
+      min_size: 5120
+      options:
+      path_filter:
+  result:
+    append_to_file:
+    append_to_lafs_dir:
+    print_to_stdout: true
+  url: http://localhost:3456/uri
+filter:
+  - 'Длинный стринг на русском'
+  - 'Еще одна длинная строка'
+---
+
+This is a test of both unicode and prettier dumping. The above metadata comes from the [pretty-yaml](https://github.com/mk-fg/pretty-yaml) readme file.
+
+Metadata should be dumped in order.


### PR DESCRIPTION
This handles the issues raised in #9 and #10.

Very simply, it allows passing keyword arguments to `frontmatter.dump` and `frontmatter.dumps`, which will then be forwarded to `yaml.dump`. By default, `frontmatter.dumps` sets `Dumper` to `yaml.SafeDumper` (or its C-variant), so current usage should work as expected.

@maxgrenderjones: Would appreciate a look on this. See if it works for your project.