### PR TITLE
add support for TOML and JSON frontmatter

### DIFF
--- a/frontmatter/__init__.py
+++ b/frontmatter/__init__.py
@@ -14,27 +14,58 @@ try:
     from yaml import CSafeDumper as SafeDumper
 except ImportError:
     from yaml import SafeDumper
+try:
+    import toml
+except ImportError:
+    toml = None
+import json
 
 from .util import u
 
 __all__ = ['parse', 'load', 'loads', 'dump', 'dumps']
 
-# match three or more dashes
-# split on this
-FM_BOUNDARY = re.compile(r'^-{3,}$', re.MULTILINE)
-
 POST_TEMPLATE = """\
----
+{start_delimiter}
 {metadata}
----
+{end_delimiter}
 
 {content}
 """
 
 
-def parse(text, **defaults):
+class YAMLHandler(object):
+    def load(self, fm):
+        return yaml.safe_load(fm)
+
+    def split(self, text):
+        FM_BOUNDARY = re.compile(r'^-{3,}$', re.MULTILINE)
+        _, fm, content = FM_BOUNDARY.split(text, 2)
+        return fm, content
+
+
+class TOMLHandler(object):
+    def load(self, fm):
+        return toml.loads(fm)
+
+    def split(self, text):
+        FM_BOUNDARY = re.compile(r'^\+{3,}$', re.MULTILINE)
+        _, fm, content = FM_BOUNDARY.split(text, 2)
+        return fm, content
+
+
+class JSONHandler(object):
+    def load(self, fm):
+        return json.loads(fm)
+
+    def split(self, text):
+        FM_BOUNDARY = re.compile(r'^(?:{|})$', re.MULTILINE)
+        _, fm, content = FM_BOUNDARY.split(text, 2)
+        return "{" + fm + "}", content
+
+
+def parse(text, add_handlers=None, **defaults):
     """
-    Parse text with YAML frontmatter, return metadata and content.
+    Parse text with frontmatter, return metadata and content.
     Pass in optional metadata defaults as keyword args.
 
     If frontmatter is not found, returns an empty metadata dictionary
@@ -46,22 +77,40 @@ def parse(text, **defaults):
     # metadata starts with defaults
     metadata = defaults.copy()
 
-    # split on the first two triple-dashes
+    handlers = {
+        '---': YAMLHandler(),
+        '{': JSONHandler(),
+    }
+
+    if toml is not None:
+        handlers['+++'] = TOMLHandler()
+
+    if add_handlers is not None:
+        handlers.update(add_handlers)
+
+    for delim in handlers:
+        if text.strip().startswith(delim):
+            handler = handlers[delim]
+            break
+    else:
+        return metadata, text
+
+    # split on the delimiters
     try:
-        _, fm, content = FM_BOUNDARY.split(text, 2)
+        fm, content = handler.split(text)
     except ValueError:
         # if we can't split, bail
         return metadata, text
 
-    # parse yaml, now that we have frontmatter
-    fm = yaml.safe_load(fm)
+    # parse, now that we have frontmatter
+    fm = handler.load(fm)
     if isinstance(fm, dict):
         metadata.update(fm)
 
     return metadata, content.strip()
 
 
-def load(fd, **defaults):
+def load(fd, add_handlers=None, **defaults):
     """
     Load and parse a file or filename, return a post.
     """
@@ -72,14 +121,14 @@ def load(fd, **defaults):
         with codecs.open(fd, 'r', 'utf-8') as f:
             text = f.read()
 
-    return loads(text, **defaults)
+    return loads(text, add_handlers, **defaults)
 
 
-def loads(text, **defaults):
+def loads(text, add_handlers=None, **defaults):
     """
     Parse text and return a post.
     """
-    metadata, content = parse(text, **defaults)
+    metadata, content = parse(text, add_handlers, **defaults)
     return Post(content, **metadata)
 
 
@@ -102,15 +151,26 @@ def dumps(post, **kwargs):
     """
     kwargs.setdefault('Dumper', SafeDumper)
     kwargs.setdefault('default_flow_style', False)
+    start_delimiter = '---'
+    if 'start_delimiter' in kwargs:
+        start_delimiter = kwargs['start_delimiter']
+        del kwargs['start_delimiter']
+    end_delimiter = '---'
+    if 'end_delimiter' in kwargs:
+        end_delimiter = kwargs['end_delimiter']
+        del kwargs['end_delimiter']
 
     metadata = yaml.dump(post.metadata, **kwargs).strip()
     metadata = u(metadata) # ensure unicode
-    return POST_TEMPLATE.format(metadata=metadata, content=post.content).strip()
+    return POST_TEMPLATE.format(
+        metadata=metadata, content=post.content,
+        start_delimiter=start_delimiter,
+        end_delimiter=end_delimiter).strip()
 
 
 class Post(object):
     """
-    A post contains content and metadata from YAML Front Matter.
+    A post contains content and metadata from Front Matter.
     For convenience, metadata values are available as proxied item lookups. 
 
     Don't use this class directly. Use module-level functions load, dump, etc.
@@ -118,7 +178,7 @@ class Post(object):
     def __init__(self, content, **metadata):
         self.content = u(content)
         self.metadata = metadata
-    
+
     def __getitem__(self, name):
         "Get metadata key"
         return self.metadata[name]        

--- a/test.py
+++ b/test.py
@@ -17,6 +17,10 @@ try:
     import pyaml
 except ImportError:
     pyaml = None
+try:
+    import toml
+except ImportError:
+    toml = None
 
 
 class FrontmatterTest(unittest.TestCase):
@@ -99,6 +103,54 @@ class FrontmatterTest(unittest.TestCase):
 
             self.assertEqual(dump, data)
             self.assertTrue(yaml in dump)
+
+    def test_dumping_with_custom_delimiters(self):
+        "dump with custom delimiters"
+        post = frontmatter.load('tests/hello-world.markdown')
+        dump = frontmatter.dumps(post,
+                                 start_delimiter='+++',
+                                 end_delimiter='+++')
+        self.assertTrue('+++' in dump)
+
+    def test_toml(self):
+        "load toml frontmatter"
+        if toml is None:
+            return
+        post = frontmatter.load('tests/hello-toml.markdown')
+        metadata = {'author': 'bob', 'something': 'else', 'test': 'tester'}
+        for k, v in metadata.items():
+            self.assertEqual(post[k], v)
+
+    def test_json(self):
+        "load raw JSON frontmatter"
+        post = frontmatter.load('tests/hello-json.markdown')
+        metadata = {'author': 'bob', 'something': 'else', 'test': 'tester'}
+        for k, v in metadata.items():
+            self.assertEqual(post[k], v)
+
+    def test_custom_handler(self):
+        "allow caller to specify a custom delimiter/handler"
+
+        # not including this in the regular test directory
+        # because it would/should be invalid per the defaults
+        custom = """...
+dummy frontmatter
+...
+dummy content"""
+
+        # and a custom handler that really doesn't do anything
+        class DummyHandler(object):
+            def load(self, fm):
+                return {'value': fm}
+
+            def split(self, text):
+                return "dummy frontmatter", "dummy content"
+
+        # but we tell frontmatter that it is the appropriate handler
+        # for the '...' delimiter
+        post = frontmatter.loads(custom, add_handlers={'...': DummyHandler()})
+
+        self.assertEqual(post['value'], 'dummy frontmatter')
 
 
 if __name__ == "__main__":

--- a/tests/hello-json.markdown
+++ b/tests/hello-json.markdown
@@ -1,0 +1,18 @@
+{
+    "test": "tester",
+    "author": "bob",
+    "something": "else"
+}
+
+Title
+=====
+
+title2
+------
+
+Hello.
+
+Just need three dashes
+---
+
+And this might break.

--- a/tests/hello-toml.markdown
+++ b/tests/hello-toml.markdown
@@ -1,0 +1,18 @@
++++
+test = "tester"
+author = "bob"
+something = "else"
++++
+
+Title
+=====
+
+title2
+------
+
+Hello.
+
+Just need three dashes
+---
+
+And this might break.


### PR DESCRIPTION
As discussed in #14, this PR adds support for TOML and JSON frontmatter.

Auto-detect based on delimiter. Defaults:

    --- for YAML
    +++ for TOML
    { and } for JSON

This can also be overridden with custom delimiter to parser mappings.

Eg,

```python
# for some reason, we want '---' to indicate toml and '+++' to indicate yaml
post = frontmatter.load('file.markdown',
                        add_handlers={'---': frontmatter.TOMLHandler(),
                                      '+++': frontmatter.YAMLHandler})
# or we have some other custom format that we'd like to use instead
post = frontmatter.load('file.markdown', add_handlers={'---': CustomHandler()})
```

The TOML parsing relies on [toml](https://pypi.python.org/pypi/toml/) being installed is only available if it can import.

Detection is a simple matter of looking at the beginning of the file to check for any of the known delimiters. I suppose this could be made more robust, but is straightforward and ought to be reliable enough for most well-formed content.

It already supports a custom Dumper, so I just extended it a bit to also allow you to pass custom start/end delimiters as well.

IMO, it would be nice if the Post knew which format it had been parsed from, so you could easily re-serialize the same way, but that can wait.

