### PR TITLE
Add three dots as ending metadata delimiter

### DIFF
--- a/test.py
+++ b/test.py
@@ -100,6 +100,18 @@ class FrontmatterTest(unittest.TestCase):
             self.assertEqual(dump, data)
             self.assertTrue(yaml in dump)
 
+    def test_with_dots(self):
+        "Parse frontmatter and text with ... as metadata end delimiter"
+        post = frontmatter.load('tests/dots.markdown')
+
+        metadata = {'title': 'Hello, world!', 'layout': 'post'}
+        for k, v in metadata.items():
+            self.assertEqual(post[k], v)
+
+        # test unicode and bytes
+        text = "Well, hello there, world."
+        self.assertEqual(six.text_type(post), text)
+        self.assertEqual(six.binary_type(post), text.encode('utf-8'))
 
 if __name__ == "__main__":
     doctest.testfile('README.md')

--- a/tests/dots.markdown
+++ b/tests/dots.markdown
@@ -1,0 +1,6 @@
+---
+title: Hello, world!
+layout: post
+...
+
+Well, hello there, world.


### PR DESCRIPTION
Since this replaces the regex match with a loop, it also fixes the
windows bug where re.MULTILINE somehow fails with \r\n

Tested on Python 3 but should work in 2.6
(If you want to deprecate 2.6 support the code can be improved by adding
a finally clause to the for loop)

Fixes #16 #17