### PR TITLE
CRLF messes with frontmatter.parse

### DIFF
--- a/frontmatter/__init__.py
+++ b/frontmatter/__init__.py
@@ -41,7 +41,10 @@ def parse(text, **defaults):
     and original text content.
     """
     # ensure unicode first
-    text = u(text)
+    if six.PY3:
+        text = codecs.decode(bytes(text, 'utf-8').replace(b'\r\n', b'\n'), 'utf-8')
+    else:
+        text = u(text.replace('\r\n', '\n'))
 
     # metadata starts with defaults
     metadata = defaults.copy()

--- a/test.py
+++ b/test.py
@@ -100,6 +100,12 @@ class FrontmatterTest(unittest.TestCase):
             self.assertEqual(dump, data)
             self.assertTrue(yaml in dump)
 
+    def test_with_crlf_string(self):
+        import codecs
+        markdown_bytes = b'---\r\ntitle: "my title"\r\ncontent_type: "post"\r\npublished: no\r\n---\r\n\r\nwrite your content in markdown here'
+        loaded = frontmatter.loads(codecs.decode(markdown_bytes, 'utf-8'))
+        self.assertEqual(loaded['title'], 'my title')
+
 
 if __name__ == "__main__":
     doctest.testfile('README.md')


### PR DESCRIPTION
### Background

When a string contains CRLF characters, the regex used in `frontmatter.parse` fails to extract yaml frontmatter.

### Repro

``` python
import codecs
import frontmatter
markdown_bytes = b'---\r\ntitle: "my title"\r\ncontent_type: "post"\r\npublished: no\r\n---\r\n\r\nwrite your content in markdown here'
loaded = frontmatter.loads(codecs.decode(markdown_bytes, 'utf-8'))
# raises KeyError
assert loaded['title'] == 'my title'
```

Fixed for both py2 and py3
