### PR TITLE
Add unicode-option to YAML metadata dump.

### DIFF
--- a/frontmatter/default_handlers.py
+++ b/frontmatter/default_handlers.py
@@ -213,7 +213,7 @@ class YAMLHandler(BaseHandler):
         kwargs.setdefault('Dumper', SafeDumper)
         kwargs.setdefault('default_flow_style', False)
 
-        metadata = yaml.dump(metadata, **kwargs).strip()
+        metadata = yaml.dump(metadata, allow_unicode=True, **kwargs).strip()
         return u(metadata) # ensure unicode
 
 


### PR DESCRIPTION
I had some issues saving Hungarian text with lots of accents. The YAML metadata always came out encoded with `\x` and `\u` escapes.

After short investigations, I found out that YAML needs a parameter to correctly dump unicode.

This PR adds the said parameter. Hope it's useful.

Reference: https://stackoverflow.com/a/29600111/3983708