### PR TITLE
 test: Add a HandlerBaseTest #46

### DIFF
--- a/test.py
+++ b/test.py
@@ -349,6 +349,34 @@ And this shouldn't break.''',
             },
         }
 
+class JSONHandlerTest(HandlerBaseTest, unittest.TestCase):
+    def setUp(self):
+        self.handler = JSONHandler()
+        self.data = {
+            'filename': 'tests/hello-json.markdown',
+            # TODO: JSONHandler.split() is prepending '\n' to the content
+            'content' : '''\
+
+
+Title
+=====
+
+title2
+------
+
+Hello.
+
+Just need three dashes
+---
+
+And this might break.
+''',
+            'metadata': {
+                "test": "tester",
+                "author": "bob",
+                "something": "else",
+            },
+        }
 if __name__ == "__main__":
     doctest.testfile('README.md')
     doctest.testmod(frontmatter.default_handlers, extraglobs={'frontmatter': frontmatter})

--- a/test.py
+++ b/test.py
@@ -236,10 +236,6 @@ class HandlerTest(unittest.TestCase):
             self.assertEqual(post[k], v)
 
 
-    def test_json_output(self):
-        "load, export, and reload"
-
-
 class HandlerBaseTest():
     """
     Tests for frontmatter.handlers

--- a/test.py
+++ b/test.py
@@ -321,6 +321,33 @@ class HandlerBaseTest():
 
         self.assertEqual(fm_export, fm)
 
+class YAMLHandlerTest(HandlerBaseTest, unittest.TestCase):
+    def setUp(self):
+        self.handler = YAMLHandler()
+        self.data = {
+            'filename': 'tests/hello-markdown.markdown',
+            # TODO: YAMLHandler.split() is prepending '\n' to the content
+            'content' : '''\
+
+
+Title
+=====
+
+title2
+------
+
+Hello.
+
+Just need three dashes
+---
+
+And this shouldn't break.''',
+            'metadata': {
+                "test": "tester",
+                "author": "bob",
+                "something": "else",
+            },
+        }
 
 if __name__ == "__main__":
     doctest.testfile('README.md')

--- a/test.py
+++ b/test.py
@@ -377,6 +377,36 @@ And this might break.
                 "something": "else",
             },
         }
+
+class TOMLHandlerTest(HandlerBaseTest, unittest.TestCase):
+    def setUp(self):
+        self.handler = TOMLHandler()
+        self.data = {
+            'filename': 'tests/hello-toml.markdown',
+            # TODO: TOMLHandler.split() is prepending '\n' to the content
+            'content' : '''\
+
+
+Title
+=====
+
+title2
+------
+
+Hello.
+
+Just need three dashes
+---
+
+And this shouldn't break.
+''',
+            'metadata': {
+                "test": "tester",
+                "author": "bob",
+                "something": "else",
+            },
+        }
+
 if __name__ == "__main__":
     doctest.testfile('README.md')
     doctest.testmod(frontmatter.default_handlers, extraglobs={'frontmatter': frontmatter})


### PR DESCRIPTION
issue: #46 
status: merge

The following TODOs are noted but out of scope for this PR

### TODO: handler.split() is prepending '\n' to the content

```
→ grep TODO test.py 
            # TODO: YAMLHandler.split() is prepending '\n' to the content
            # TODO: JSONHandler.split() is prepending '\n' to the content
            # TODO: TOMLHandler.split() is prepending '\n' to the content
```

### TODO: fronmatter.load() is stripping whitespace

```
content_stripped = content.strip()
self.assertEqual(post.content, content_stripped)
```
