### PR TITLE
Set allow_unicode to true by default in YAMLHandler.export

### DIFF
--- a/frontmatter/default_handlers.py
+++ b/frontmatter/default_handlers.py
@@ -212,6 +212,7 @@ class YAMLHandler(BaseHandler):
         """
         kwargs.setdefault('Dumper', SafeDumper)
         kwargs.setdefault('default_flow_style', False)
+        kwargs.setdefault('allow_unicode', True)
 
         metadata = yaml.dump(metadata, **kwargs).strip()
         return u(metadata) # ensure unicode

--- a/test.py
+++ b/test.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 from __future__ import unicode_literals
 from __future__ import print_function
 

--- a/test.py
+++ b/test.py
@@ -50,8 +50,13 @@ class FrontmatterTest(unittest.TestCase):
     def test_unicode_post(self):
         "Ensure unicode is parsed correctly"
         chinese = frontmatter.load('tests/chinese.txt', 'utf-8')
+        output = frontmatter.dumps(chinese)
+        zh = "中文"
 
         self.assertTrue(isinstance(chinese.content, six.text_type))
+
+        # check that we're dumping out unicode metadata, too
+        self.assertTrue(zh in output)
 
         # this shouldn't work as ascii, because it's Hanzi
         self.assertRaises(UnicodeEncodeError, chinese.content.encode, 'ascii')

--- a/tests/chinese.txt
+++ b/tests/chinese.txt
@@ -1,5 +1,6 @@
 ---
 title: "Let's try unicode"
+language: 中文
 ---
 
 欢迎来到大连水产学院！


### PR DESCRIPTION
Alternate approach to #39 with tests and a default. If for some reason you don't want unicode, you can turn it off.