### PR TITLE
Fix JSON output

### DIFF
--- a/frontmatter/default_handlers.py
+++ b/frontmatter/default_handlers.py
@@ -225,8 +225,8 @@ class JSONHandler(BaseHandler):
     Note that changing ``START_DELIMITER`` or ``END_DELIMITER`` may break JSON parsing.
     """
     FM_BOUNDARY = re.compile(r'^(?:{|})$', re.MULTILINE)
-    START_DELIMITER = "{"
-    END_DELIMITER = "}"
+    START_DELIMITER = ""
+    END_DELIMITER = ""
 
     def split(self, text):
         _, fm, content = self.FM_BOUNDARY.split(text, 2)
@@ -237,6 +237,7 @@ class JSONHandler(BaseHandler):
 
     def export(self, metadata, **kwargs):
         "Turn metadata into JSON"
+        kwargs.setdefault('indent', 4)
         metadata = json.dumps(metadata, **kwargs)
         return u(metadata)
 

--- a/test.py
+++ b/test.py
@@ -150,18 +150,37 @@ class HandlerTest(unittest.TestCase):
     """
     Tests for custom handlers and formatting
     """
+    TEST_FILES = {
+        'tests/hello-world.markdown': YAMLHandler, 
+        'tests/hello-json.markdown': JSONHandler,
+        'tests/hello-toml.markdown': TOMLHandler
+    }
+
+    def sanity_check(self, filename, handler_type):
+        "Ensure we can load -> dump -> load"
+        post = frontmatter.load(filename)
+
+        self.assertIsInstance(post.handler, handler_type)
+
+        # dump and reload
+        repost = frontmatter.loads(frontmatter.dumps(post))
+
+        self.assertEqual(post.metadata, repost.metadata)
+        self.assertEqual(post.content, repost.content)
+        self.assertEqual(post.handler, repost.handler)
+
     def test_detect_format(self):
         "detect format based on default handlers"
-        test_files = {
-            'tests/hello-world.markdown': YAMLHandler, 
-            'tests/hello-json.markdown': JSONHandler,
-            'tests/hello-toml.markdown': TOMLHandler
-        }
 
-        for fn, Handler in test_files.items():
-            with codecs.open(fn, 'r', 'utf-8') as f:
+        for filename, Handler in self.TEST_FILES.items():
+            with codecs.open(filename, 'r', 'utf-8') as f:
                 format = frontmatter.detect_format(f.read(), frontmatter.handlers)
                 self.assertIsInstance(format, Handler)
+
+    def test_sanity_all(self):
+        "Run sanity check on all handlers"
+        for filename, Handler in self.TEST_FILES.items():
+            self.sanity_check(filename, Handler)
 
     def test_no_handler(self):
         "default to YAMLHandler when no handler is attached"
@@ -215,6 +234,10 @@ class HandlerTest(unittest.TestCase):
         metadata = {'author': 'bob', 'something': 'else', 'test': 'tester'}
         for k, v in metadata.items():
             self.assertEqual(post[k], v)
+
+
+    def test_json_output(self):
+        "load, export, and reload"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #55 

The default delimiters were creating bad output. This also adds a `sanity_check` function to check that `frontmatter.loads(frontmatter.dumps(post))` doesn't break.