### PR TITLE
Add two functions to check if text or file has a frontmatter

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8,6 +8,10 @@ Reading
 
 .. autofunction:: frontmatter.parse
 
+.. autofunction:: frontmatter.check
+
+.. autofunction:: frontmatter.checks
+
 .. autofunction:: frontmatter.load
 
 .. autofunction:: frontmatter.loads

--- a/frontmatter/__init__.py
+++ b/frontmatter/__init__.py
@@ -91,6 +91,43 @@ def parse(text, encoding="utf-8", handler=None, **defaults):
     return metadata, content.strip()
 
 
+def check(fd, encoding="utf-8"):
+    """
+    Check if a file-like object or filename has a frontmatter, 
+    return True if exists, False otherwise.
+
+    ::
+
+        >>> frontmatter.check('tests/hello-world.markdown')
+        True
+
+    """
+    if hasattr(fd, "read"):
+        text = fd.read()
+
+    else:
+        with codecs.open(fd, "r", encoding) as f:
+            text = f.read()
+
+    return checks(text, encoding)
+
+
+def checks(text, encoding="utf-8"):
+    """
+    Check if a text (binary or unicode) has a frontmatter,
+    return True if exists, False otherwise.
+
+    ::
+
+        >>> with open('tests/hello-world.markdown') as f:
+        ...     frontmatter.checks(f.read())
+        True
+
+    """
+    text = u(text, encoding)
+    return detect_format(text, handlers) != None
+
+
 def load(fd, encoding="utf-8", handler=None, **defaults):
     """
     Load and parse a file-like object or filename, 

--- a/frontmatter/__init__.py
+++ b/frontmatter/__init__.py
@@ -95,6 +95,8 @@ def check(fd, encoding="utf-8"):
     """
     Check if a file-like object or filename has a frontmatter, 
     return True if exists, False otherwise.
+    
+    If it contains a frontmatter but it is empty, return True as well.
 
     ::
 
@@ -116,6 +118,8 @@ def checks(text, encoding="utf-8"):
     """
     Check if a text (binary or unicode) has a frontmatter,
     return True if exists, False otherwise.
+    
+    If it contains a frontmatter but it is empty, return True as well.
 
     ::
 

--- a/test.py
+++ b/test.py
@@ -63,6 +63,18 @@ class FrontmatterTest(unittest.TestCase):
 
         # this shouldn't work as ascii, because it's Hanzi
         self.assertRaises(UnicodeEncodeError, chinese.content.encode, "ascii")
+    
+    def test_check_no_frontmatter(self):
+        "Checks if a file does not have a frontmatter"
+        ret = frontmatter.check("tests/no-frontmatter.txt")
+        
+        self.assertEqual(ret, False)
+    
+    def test_check_empty_frontmatter(self):
+        "Checks if a file has a frontmatter (empty or not)"
+        ret = frontmatter.check("tests/no-frontmatter.txt")
+        
+        self.assertEqual(ret, True)
 
     def test_no_frontmatter(self):
         "This is not a zen exercise."

--- a/test.py
+++ b/test.py
@@ -72,7 +72,7 @@ class FrontmatterTest(unittest.TestCase):
     
     def test_check_empty_frontmatter(self):
         "Checks if a file has a frontmatter (empty or not)"
-        ret = frontmatter.check("tests/no-frontmatter.txt")
+        ret = frontmatter.check("tests/empty-frontmatter.txt")
         
         self.assertEqual(ret, True)
 


### PR DESCRIPTION
Although there is a `detect_format` function, which checks if there is
any handler that can check the file or string for a frontmatter, there
is no explicit function to check if a string or file has a frontmatter
without having to do the parse the file or string and check for metadata
set.

Thus, to make a frontmatter check on files or strings more explicit,
without necessarily parsing, two functions have been added: `check` and`
checks`, which use the `detect_format` function to do so.