### PR TITLE
Add README text explaining how to easily strip a BOM from a UTF-8 file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ Or load from text:
 
 ```
 
+If the file has a [Byte-Order Mark](https://en.wikipedia.org/wiki/Byte_order_mark) (BOM), strip it off first. An easy way to do this is by using the [`utf-8-sig`](https://docs.python.org/3/library/codecs.html?highlight=utf%208%20sig#module-encodings.utf_8_sig) encoding:
+
+```python
+>>> with open('tests/yaml/hello-world.txt', encoding="utf-8-sig") as f:
+...     post = frontmatter.load(f)
+
+```
+
 Access content:
 
 ```python


### PR DESCRIPTION
I spent a few minutes today figuring out why `frontmatter` wasn't successfully parsing a handful of files. It turned out that the reason was that just a few of my files had a BOM. I thought I'd try to save the next coder a few minutes of hassle by providing a simple solution in the README.