### PR TITLE
Include newline at the end of files generated by format().

### DIFF
--- a/frontmatter/default_handlers.py
+++ b/frontmatter/default_handlers.py
@@ -221,7 +221,7 @@ class BaseHandler:
             content=post.content,
             start_delimiter=start_delimiter,
             end_delimiter=end_delimiter,
-        ).strip()
+        ).lstrip()
 
 
 class YAMLHandler(BaseHandler):


### PR DESCRIPTION
Posix mandates a newline at the end of a file. Presently, when frontmatter generates a string using `format()`, it doesn't include a newline at the end. Since `dump()` calls `format()` and then just saves that string, the file is generated without a newline.

I have proposed a solution in this PR, but perhaps you would prefer to have the EOF newline added only in the `dump` case.