### PR TITLE
Include py.typed marker in package distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include LICENSE
 include README.md
+include frontmatter/py.typed
 
 recursive-include tests *
 

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
     author_email="eyeseast@gmail.com",
     url="https://github.com/eyeseast/python-frontmatter",
     packages=["frontmatter"],
+    package_data={"frontmatter": ["py.typed"]},
     include_package_data=True,
     install_requires=["PyYAML"],
     extras_require={


### PR DESCRIPTION
Fixes #112

The `py.typed` marker file was added in #111 but wasn't being distributed in the PyPI package, so mypy still complains about missing type stubs.

```
error: Skipping analyzing "frontmatter": module is installed, but missing library stubs or py.typed marker  [import-untyped]
```

This adds `package_data` to `setup.py` as recommended by [PEP 561](https://peps.python.org/pep-0561/#packaging-type-information), and updates `MANIFEST.in` to ensure the file is included in source distributions.